### PR TITLE
Fixed looking for "Transformer" class in different package than original...

### DIFF
--- a/android-transformer/src/main/java/com/mobandme/android/transformer/Transformer.java
+++ b/android-transformer/src/main/java/com/mobandme/android/transformer/Transformer.java
@@ -88,13 +88,7 @@ public final class Transformer {
     }
     
     private String getTransformerCanonicalName() {
-        String result;
-        
-        String packageName = String.format(Tools.TRANSFORMER_PACKAGE_PATTERN, transformerType.getPackage().getName());
-        String className = Tools.TRANSFORMER_CLASS_NAME;
-        result = String.format("%s.%s", packageName, className);
-        
-        return result;
+        return String.format("%s.%s", Tools.TRANSFORMER_PACKAGE, Tools.TRANSFORMER_CLASS_NAME);
     }
     
     private AbstractTransformer getTransformerInstance(String transformerCanonicalName) {

--- a/android-transformer/src/main/java/com/mobandme/android/transformer/internal/AnnotationsProcessor.java
+++ b/android-transformer/src/main/java/com/mobandme/android/transformer/internal/AnnotationsProcessor.java
@@ -85,17 +85,15 @@ public class AnnotationsProcessor extends AbstractProcessor {
         try {
 
             if (mappersList.size() > 0) {
-                MapperInfo firstMapper = (MapperInfo)mappersList.values().toArray()[0];
 
-                String packageName = String.format(Tools.TRANSFORMER_PACKAGE_PATTERN, firstMapper.packageName);
                 String className = Tools.TRANSFORMER_CLASS_NAME;
 
-                writeTrace(String.format("Generating source file for Transformer class with name %s.%s", packageName, className));
+                writeTrace(String.format("Generating source file for Transformer class with name %s.%s", Tools.TRANSFORMER_PACKAGE, className));
 
                 JavaFileObject javaFileObject = processingEnv.getFiler().createSourceFile(className);
                 BufferedWriter buffer = new BufferedWriter(javaFileObject.openWriter());
 
-                buffer.append(String.format(Tools.PACKAGE_PATTERN, packageName));
+                buffer.append(String.format(Tools.PACKAGE_PATTERN, Tools.TRANSFORMER_PACKAGE));
                 buffer.newLine();
 
                 //region "Class Imports Generation"

--- a/android-transformer/src/main/java/com/mobandme/android/transformer/internal/Tools.java
+++ b/android-transformer/src/main/java/com/mobandme/android/transformer/internal/Tools.java
@@ -29,7 +29,7 @@ public class Tools {
     public final static String PACKAGE_PATTERN = "package %s;";
     public final static String CLASS_PATTERN = "public class %s {";
     public final static String TRANSFORMER_CLASS_NAME = "Transformer";
-    public final static String TRANSFORMER_PACKAGE_PATTERN = "%s.transformer";
+    public final static String TRANSFORMER_PACKAGE = "com.mobandme.android.transformer.config";
     public final static String TRANSFORMER_CLASS_PATTERN = "public final class %s extends AbstractTransformer {";
     public final static String IMPORT_PATTERN = "import %s.%s;";
     public final static String MAPPER_PACKAGE_PATTERN = "%s.mapper";


### PR DESCRIPTION
When you have model in different packages for ex:

``` java
me.panavtec.app.domain.entities.*
me.panavtec.app.data.entities.*
```

If you are using @Mappable in the 2 directories, the generator of "Transformer" class is allways using first package so it will crash. This fixes it using allways the package "com.mobandme.android.transformer.config" (Tools) to generate "Transformer"
